### PR TITLE
Make CodeMirror build on Windows.

### DIFF
--- a/bin/cm.js
+++ b/bin/cm.js
@@ -217,7 +217,7 @@ function ensureSelfLink() {
   let parent = path.join(root, "node_modules", "@codemirror"), link = path.join(parent, "next")
   if (!fs.existsSync(link)) {
     fs.mkdirSync(parent, {recursive: true})
-    fs.symlinkSync("../..", link)
+    fs.symlinkSync("../..", link, "junction")
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "test": "npm run test-node && node bin/selenium.js --start-server",
     "test-node": "mocha text/test/test-*.js state/test/test-*.js history/test/test-*.js rangeset/test/test-rangeset.js view/test/test-heightmap.js commands/test/test-*.js lang-javascript/test/test-*.js closebrackets/test/test-*.js search/test/test-*.js collab/test/test-*.js comment/test/test-*.js",
-    "prepare": "bin/cm.js build",
-    "dev": "bin/cm.js devserver"
+    "prepare": "node bin/cm.js build",
+    "dev": "node bin/cm.js devserver"
   },
   "keywords": [
     "editor",


### PR DESCRIPTION
 - invoke `node` manually in `prepare` and `dev` scripts since Windows doesn't understand `#!`
 - symlinkSync on Windows need the `type` argument (ignored on other OSes).